### PR TITLE
「退社します」が反応しない不具合を修正

### DIFF
--- a/main.gs
+++ b/main.gs
@@ -743,7 +743,7 @@ loadTimesheets = function (exports) {
 
     // コマンド集
     var commands = [
-      ['doNothing', /^\./] // '.'から始まるメッセージは何もしない
+      ['doNothing', /^\./], // '.'から始まるメッセージは何もしない
       ['actionSignOut', /(退社|taisya|退勤)(した|しました|していました|しています|します|simasita|simasu)/],
       ['actionWhoIsOff', /(((だれ|誰|who\s*is).*(休|やす(ま|み|む)))|((休みの|休暇の|休んでいる)人))/],
       ['actionWhoIsIn', /(だれ|誰|who\s*is)/],

--- a/scripts/timesheets.js
+++ b/scripts/timesheets.js
@@ -26,7 +26,7 @@ loadTimesheets = function (exports) {
 
     // コマンド集
     var commands = [
-      ['doNothing', /^\./] // '.'から始まるメッセージは何もしない
+      ['doNothing', /^\./], // '.'から始まるメッセージは何もしない
       ['actionSignOut', /(退社|taisya|退勤)(した|しました|していました|しています|します|simasita|simasu)/],
       ['actionWhoIsOff', /(((だれ|誰|who\s*is).*(休|やす(ま|み|む)))|((休みの|休暇の|休んでいる)人))/],
       ['actionWhoIsIn', /(だれ|誰|who\s*is)/],


### PR DESCRIPTION
- 配列の要素が`,`で区切られていない部分を修正し、構文的に正しくなるように修正しました
- 「退社しました」などに正常に反応するようになりました

#7 について作業しました