### PR TITLE
実際の出社・退社メッセージにのみ反応するよう修正

### DIFF
--- a/main.gs
+++ b/main.gs
@@ -744,12 +744,12 @@ loadTimesheets = function (exports) {
     // コマンド集
     var commands = [
       ['doNothing', /^\./], // '.'から始まるメッセージは何もしない
-      ['actionSignOut', /(:walking:|:woman-walking:|:man-walking:)\s*(退社|taisya|退勤)(した|しました|していました|しています|します|simasita|simasu)/],
+      ['actionSignOut', /(:walking:|:woman-walking:|:man-walking:)\s*(退社|taisya|退勤|作業終了)(した|しました|していました|しています|します|simasita|simasu)/],
       ['actionWhoIsOff', /(((だれ|誰|who\s*is).*(休|やす(ま|み|む)))|((休みの|休暇の|休んでいる)人))/],
       ['actionWhoIsIn', /(だれ|誰|who\s*is)/],
       ['actionCancelOff', /(休|やす(ま|み|む)|休暇).*(キャンセル|消|止|やめ|ません)/],
       ['actionOff', /(休|やす(ま|み|む)|休暇)/],
-      ['actionSignIn', /(:walking:|:woman-walking:|:man-walking:)\s*(出社|syussya|出勤)(した|しました|していました|しています|します|simasita|simasu)/],
+      ['actionSignIn', /(:walking:|:woman-walking:|:man-walking:)\s*(出社|syussya|出勤|作業開始)(した|しました|していました|しています|します|simasita|simasu)/],
       ['confirmSignIn', /__confirmSignIn__/],
       ['confirmSignOut', /__confirmSignOut__/],
     ];

--- a/main.gs
+++ b/main.gs
@@ -744,12 +744,12 @@ loadTimesheets = function (exports) {
     // コマンド集
     var commands = [
       ['doNothing', /^\./], // '.'から始まるメッセージは何もしない
-      ['actionSignOut', /(退社|taisya|退勤)(した|しました|していました|しています|します|simasita|simasu)/],
+      ['actionSignOut', /(:walking:|:woman-walking:|:man-walking:)\s*(退社|taisya|退勤)(した|しました|していました|しています|します|simasita|simasu)/],
       ['actionWhoIsOff', /(((だれ|誰|who\s*is).*(休|やす(ま|み|む)))|((休みの|休暇の|休んでいる)人))/],
       ['actionWhoIsIn', /(だれ|誰|who\s*is)/],
       ['actionCancelOff', /(休|やす(ま|み|む)|休暇).*(キャンセル|消|止|やめ|ません)/],
       ['actionOff', /(休|やす(ま|み|む)|休暇)/],
-      ['actionSignIn', /(出社|syussya|出勤)(した|しました|していました|しています|します|simasita|simasu)/],
+      ['actionSignIn', /(:walking:|:woman-walking:|:man-walking:)\s*(出社|syussya|出勤)(した|しました|していました|しています|します|simasita|simasu)/],
       ['confirmSignIn', /__confirmSignIn__/],
       ['confirmSignOut', /__confirmSignOut__/],
     ];

--- a/scripts/timesheets.js
+++ b/scripts/timesheets.js
@@ -27,12 +27,12 @@ loadTimesheets = function (exports) {
     // コマンド集
     var commands = [
       ['doNothing', /^\./], // '.'から始まるメッセージは何もしない
-      ['actionSignOut', /(:walking:|:woman-walking:|:man-walking:)\s*(退社|taisya|退勤)(した|しました|していました|しています|します|simasita|simasu)/],
+      ['actionSignOut', /(:walking:|:woman-walking:|:man-walking:)\s*(退社|taisya|退勤|作業終了)(した|しました|していました|しています|します|simasita|simasu)/],
       ['actionWhoIsOff', /(((だれ|誰|who\s*is).*(休|やす(ま|み|む)))|((休みの|休暇の|休んでいる)人))/],
       ['actionWhoIsIn', /(だれ|誰|who\s*is)/],
       ['actionCancelOff', /(休|やす(ま|み|む)|休暇).*(キャンセル|消|止|やめ|ません)/],
       ['actionOff', /(休|やす(ま|み|む)|休暇)/],
-      ['actionSignIn', /(:walking:|:woman-walking:|:man-walking:)\s*(出社|syussya|出勤)(した|しました|していました|しています|します|simasita|simasu)/],
+      ['actionSignIn', /(:walking:|:woman-walking:|:man-walking:)\s*(出社|syussya|出勤|作業開始)(した|しました|していました|しています|します|simasita|simasu)/],
       ['confirmSignIn', /__confirmSignIn__/],
       ['confirmSignOut', /__confirmSignOut__/],
     ];

--- a/scripts/timesheets.js
+++ b/scripts/timesheets.js
@@ -27,12 +27,12 @@ loadTimesheets = function (exports) {
     // コマンド集
     var commands = [
       ['doNothing', /^\./], // '.'から始まるメッセージは何もしない
-      ['actionSignOut', /(退社|taisya|退勤)(した|しました|していました|しています|します|simasita|simasu)/],
+      ['actionSignOut', /(:walking:|:woman-walking:|:man-walking:)\s*(退社|taisya|退勤)(した|しました|していました|しています|します|simasita|simasu)/],
       ['actionWhoIsOff', /(((だれ|誰|who\s*is).*(休|やす(ま|み|む)))|((休みの|休暇の|休んでいる)人))/],
       ['actionWhoIsIn', /(だれ|誰|who\s*is)/],
       ['actionCancelOff', /(休|やす(ま|み|む)|休暇).*(キャンセル|消|止|やめ|ません)/],
       ['actionOff', /(休|やす(ま|み|む)|休暇)/],
-      ['actionSignIn', /(出社|syussya|出勤)(した|しました|していました|しています|します|simasita|simasu)/],
+      ['actionSignIn', /(:walking:|:woman-walking:|:man-walking:)\s*(出社|syussya|出勤)(した|しました|していました|しています|します|simasita|simasu)/],
       ['confirmSignIn', /__confirmSignIn__/],
       ['confirmSignOut', /__confirmSignOut__/],
     ];


### PR DESCRIPTION
#9 に関する作業

# 変更点
- 「出社しました」「退社しました」の先頭に `:walking:` または `:man-walking:` または `:woman-walking:` の絵文字をつけた時のみ出社退社処理が行われるようにしました
    - 例「:walking:出社しました」
- 「作業開始します」「作業終了します」を出社/退社アクションとして追加しました

# スクリーンショット

絵文字付きの出社/退社アクションに反応している様子
![realsyussyataisya](https://user-images.githubusercontent.com/5213322/41758147-bf9ea55c-7621-11e8-94f0-c7794bec5884.png)

絵文字なしの言及には反応していない様子
![nores](https://user-images.githubusercontent.com/5213322/41758182-fa3ac90c-7621-11e8-95a9-f0ade7448626.png)

