### PR TITLE
「:man-walking:」「:woman-walking:」「:walking:」の絵文字がなくてもあっても打刻が可能

### DIFF
--- a/main.gs
+++ b/main.gs
@@ -760,8 +760,8 @@ loadTimesheets = function (exports) {
       ['actionCancelOff', /(休|やす(ま|み|む)|休暇).*(キャンセル|消|止|やめ|ません)/],
       ['actionOff', /(休|やす(ま|み|む)|休暇)/],
       ['actionSignIn', /^(:walking:|:woman-walking:|:man-walking:)?\s*(出社|syussya|出勤|作業開始)(した|しました|していました|しています|します|simasita|simasu)/],
-      ['actionPause', /^(:walking:|:woman-walking:|:man-walking:)?\s*作業中断(した|しました|していました|しています|します|simasita|simasu)/],
-      ['actionResume', /^(:walking:|:woman-walking:|:man-walking:)?\s*作業再開(した|しました|していました|しています|します|simasita|simasu)/ ],
+      ['actionPause', /^(:walking:|:woman-walking:|:man-walking:)?\s*作業中断(した|しました|します)/],
+      ['actionResume', /^(:walking:|:woman-walking:|:man-walking:)?\s*作業再開(した|しました|します)/ ],
       ['confirmSignIn', /__confirmSignIn__/],
       ['confirmSignOut', /__confirmSignOut__/],
     ];

--- a/main.gs
+++ b/main.gs
@@ -754,14 +754,14 @@ loadTimesheets = function (exports) {
     // コマンド集
     var commands = [
       ['doNothing', /^\./], // '.'から始まるメッセージは何もしない
-      ['actionSignOut', /(:walking:|:woman-walking:|:man-walking:)*\s*(退社|taisya|退勤|作業終了)(した|しました|していました|しています|します|simasita|simasu)/],
+      ['actionSignOut', /^(:walking:|:woman-walking:|:man-walking:)?\s*(退社|taisya|退勤|作業終了)(した|しました|していました|しています|します|simasita|simasu)/],
       ['actionWhoIsOff', /(((だれ|誰|who\s*is).*(休|やす(ま|み|む)))|((休みの|休暇の|休んでいる)人))/],
       ['actionWhoIsIn', /(だれ|誰|who\s*is)/],
       ['actionCancelOff', /(休|やす(ま|み|む)|休暇).*(キャンセル|消|止|やめ|ません)/],
       ['actionOff', /(休|やす(ま|み|む)|休暇)/],
-      ['actionSignIn', /(:walking:|:woman-walking:|:man-walking:)*\s*(出社|syussya|出勤|作業開始)(した|しました|していました|しています|します|simasita|simasu)/],
-      ['actionPause', /((:walking:|:woman-walking:|:man-walking:)*\s*作業中断)/],
-      ['actionResume', /((:walking:|:woman-walking:|:man-walking:)*\s*作業再開)/ ],
+      ['actionSignIn', /^(:walking:|:woman-walking:|:man-walking:)?\s*(出社|syussya|出勤|作業開始)(した|しました|していました|しています|します|simasita|simasu)/],
+      ['actionPause', /^(:walking:|:woman-walking:|:man-walking:)?\s*作業中断(した|しました|していました|しています|します|simasita|simasu)/],
+      ['actionResume', /^(:walking:|:woman-walking:|:man-walking:)?\s*作業再開(した|しました|していました|しています|します|simasita|simasu)/ ],
       ['confirmSignIn', /__confirmSignIn__/],
       ['confirmSignOut', /__confirmSignOut__/],
     ];

--- a/main.gs
+++ b/main.gs
@@ -754,14 +754,14 @@ loadTimesheets = function (exports) {
     // コマンド集
     var commands = [
       ['doNothing', /^\./], // '.'から始まるメッセージは何もしない
-      ['actionSignOut', /(:walking:|:woman-walking:|:man-walking:)\s*(退社|taisya|退勤|作業終了)(した|しました|していました|しています|します|simasita|simasu)/],
+      ['actionSignOut', /(:walking:|:woman-walking:|:man-walking:)*\s*(退社|taisya|退勤|作業終了)(した|しました|していました|しています|します|simasita|simasu)/],
       ['actionWhoIsOff', /(((だれ|誰|who\s*is).*(休|やす(ま|み|む)))|((休みの|休暇の|休んでいる)人))/],
       ['actionWhoIsIn', /(だれ|誰|who\s*is)/],
       ['actionCancelOff', /(休|やす(ま|み|む)|休暇).*(キャンセル|消|止|やめ|ません)/],
       ['actionOff', /(休|やす(ま|み|む)|休暇)/],
-      ['actionSignIn', /(:walking:|:woman-walking:|:man-walking:)\s*(出社|syussya|出勤|作業開始)(した|しました|していました|しています|します|simasita|simasu)/],
-      ['actionPause', /((:walking:|:woman-walking:|:man-walking:)\s*作業中断)/],
-      ['actionResume', /((:walking:|:woman-walking:|:man-walking:)\s*作業再開)/ ],
+      ['actionSignIn', /(:walking:|:woman-walking:|:man-walking:)*\s*(出社|syussya|出勤|作業開始)(した|しました|していました|しています|します|simasita|simasu)/],
+      ['actionPause', /((:walking:|:woman-walking:|:man-walking:)*\s*作業中断)/],
+      ['actionResume', /((:walking:|:woman-walking:|:man-walking:)*\s*作業再開)/ ],
       ['confirmSignIn', /__confirmSignIn__/],
       ['confirmSignOut', /__confirmSignOut__/],
     ];

--- a/scripts/timesheets.js
+++ b/scripts/timesheets.js
@@ -28,14 +28,14 @@ loadTimesheets = function (exports) {
     // コマンド集
     var commands = [
       ['doNothing', /^\./], // '.'から始まるメッセージは何もしない
-      ['actionSignOut', /(:walking:|:woman-walking:|:man-walking:)\s*(退社|taisya|退勤|作業終了)(した|しました|していました|しています|します|simasita|simasu)/],
+      ['actionSignOut', /^(:walking:|:woman-walking:|:man-walking:)?\s*(退社|taisya|退勤|作業終了)(した|しました|していました|しています|します|simasita|simasu)/],
       ['actionWhoIsOff', /(((だれ|誰|who\s*is).*(休|やす(ま|み|む)))|((休みの|休暇の|休んでいる)人))/],
       ['actionWhoIsIn', /(だれ|誰|who\s*is)/],
       ['actionCancelOff', /(休|やす(ま|み|む)|休暇).*(キャンセル|消|止|やめ|ません)/],
       ['actionOff', /(休|やす(ま|み|む)|休暇)/],
-      ['actionSignIn', /(:walking:|:woman-walking:|:man-walking:)\s*(出社|syussya|出勤|作業開始)(した|しました|していました|しています|します|simasita|simasu)/],
-      ['actionPause', /((:walking:|:woman-walking:|:man-walking:)\s*作業中断)/],
-      ['actionResume', /((:walking:|:woman-walking:|:man-walking:)\s*作業再開)/ ],
+      ['actionSignIn', /^(:walking:|:woman-walking:|:man-walking:)?\s*(出社|syussya|出勤|作業開始)(した|しました|していました|しています|します|simasita|simasu)/],
+      ['actionPause', /^(:walking:|:woman-walking:|:man-walking:)?\s*作業中断(した|しました|していました|しています|します|simasita|simasu)/],
+      ['actionResume', /^(:walking:|:woman-walking:|:man-walking:)?\s*作業再開(した|しました|していました|しています|します|simasita|simasu)/ ],
       ['confirmSignIn', /__confirmSignIn__/],
       ['confirmSignOut', /__confirmSignOut__/],
     ];

--- a/scripts/timesheets.js
+++ b/scripts/timesheets.js
@@ -34,8 +34,8 @@ loadTimesheets = function (exports) {
       ['actionCancelOff', /(休|やす(ま|み|む)|休暇).*(キャンセル|消|止|やめ|ません)/],
       ['actionOff', /(休|やす(ま|み|む)|休暇)/],
       ['actionSignIn', /^(:walking:|:woman-walking:|:man-walking:)?\s*(出社|syussya|出勤|作業開始)(した|しました|していました|しています|します|simasita|simasu)/],
-      ['actionPause', /^(:walking:|:woman-walking:|:man-walking:)?\s*作業中断(した|しました|していました|しています|します|simasita|simasu)/],
-      ['actionResume', /^(:walking:|:woman-walking:|:man-walking:)?\s*作業再開(した|しました|していました|しています|します|simasita|simasu)/ ],
+      ['actionPause', /^(:walking:|:woman-walking:|:man-walking:)?\s*作業中断(した|しました|します)/],
+      ['actionResume', /^(:walking:|:woman-walking:|:man-walking:)?\s*作業再開(した|しました|します)/ ],
       ['confirmSignIn', /__confirmSignIn__/],
       ['confirmSignOut', /__confirmSignOut__/],
     ];


### PR DESCRIPTION
#13 を実装しました。

# 変更点
- 「`:man-walking:`」「`:woman-walking:`」「`:walking:`」の絵文字がなくてもあっても打刻が可能になりました。

# スクリーンショット

- Slack で反応している様子
![capture](https://user-images.githubusercontent.com/36610811/52951786-10ce2f80-33c6-11e9-9da4-d46443293f1f.JPG)
